### PR TITLE
Append SSH_PORT option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Rsync files from a GitHub repo to a destination server over SSH
 | `SSH_PRIVATE_KEY`  | The private key part of an SSH key pair. The public key part should be added to the `authorized_keys` on the destination server. |
 | `SSH_USERNAME`     | The username to use when connecting to the destination server                                                                    |
 | `SSH_HOSTNAME`     | The hostname of the destination server                                                                                           |
+| `SSH_PORT`         | The port number of the destination server (default: 22)                                                                          |
 
 ## Required arguments
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,4 +18,4 @@ echo "  Port ${SSH_PORT:-22}"              >> "$SSH_PATH/config"
 echo "  StrictHostKeyChecking no"          >> "$SSH_PATH/config"
 
 # Do deployment
-sh -c "rsync ${INPUT_RSYNC_OPTIONS} ${GITHUB_WORKSPACE}${INPUT_RSYNC_SOURCE} rsync_target:${INPUT_RSYNC_TARGET}"
+sh -c "rsync -e 'ssh -F \"$SSH_PATH/config\"' ${INPUT_RSYNC_OPTIONS} ${GITHUB_WORKSPACE}${INPUT_RSYNC_SOURCE} rsync_target:${INPUT_RSYNC_TARGET}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,13 @@ mkdir -p "$SSH_PATH"
 echo "$SSH_PRIVATE_KEY" > "$SSH_PATH/deploy_key"
 chmod 600 "$SSH_PATH/deploy_key"
 
+# Create SSH config file
+touch "$SSH_PATH/config"
+echo "Host rsync_target"                   >> "$SSH_PATH/config"
+echo "  HostName $SSH_HOSTNAME"            >> "$SSH_PATH/config"
+echo "  User $SSH_USERNAME"                >> "$SSH_PATH/config"
+echo "  IdentityFile $SSH_PATH/deploy_key" >> "$SSH_PATH/config"
+echo "  StrictHostKeyChecking no"          >> "$SSH_PATH/config"
+
 # Do deployment
-sh -c "rsync ${INPUT_RSYNC_OPTIONS} -e 'ssh -i $SSH_PATH/deploy_key -o StrictHostKeyChecking=no' ${GITHUB_WORKSPACE}${INPUT_RSYNC_SOURCE} ${SSH_USERNAME}@${SSH_HOSTNAME}:${INPUT_RSYNC_TARGET}"
+sh -c "rsync ${INPUT_RSYNC_OPTIONS} ${GITHUB_WORKSPACE}${INPUT_RSYNC_SOURCE} rsync_target:${INPUT_RSYNC_TARGET}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ echo "Host rsync_target"                   >> "$SSH_PATH/config"
 echo "  HostName $SSH_HOSTNAME"            >> "$SSH_PATH/config"
 echo "  User $SSH_USERNAME"                >> "$SSH_PATH/config"
 echo "  IdentityFile $SSH_PATH/deploy_key" >> "$SSH_PATH/config"
+echo "  Port ${SSH_PORT:-22}"              >> "$SSH_PATH/config"
 echo "  StrictHostKeyChecking no"          >> "$SSH_PATH/config"
 
 # Do deployment


### PR DESCRIPTION
This is my first time submitting a Pull Request to someone else, so please let me know if you have any rudeness.

# Purpose
I want to specify a port when running rsync

# change point
1. For readability, create a `.ssh/config` file and specify all SSH options in it.
2. Add SSH_PORT environment variable (default: 22)